### PR TITLE
Add support for Cocoapods

### DIFF
--- a/GottaGoFast.podspec
+++ b/GottaGoFast.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name          = "GottaGoFast"
+  spec.version       = "0.2.1"
+  spec.summary       = "GottaGoFast — a Swift benchmarking library."
+
+  spec.description   = <<-DESC
+  GottaGoFast is a Swift benchmarking library.
+  DESC
+
+  spec.homepage      = "https://github.com/broadwaylamb/GottaGoFast"
+  spec.license       = 'MIT'
+
+  spec.authors       = { "Sergej Jaskiewicz" => "jaskiewiczs@icloud.com" }
+  spec.source        = { :git => "https://github.com/broadwaylamb/GottaGoFast.git", :tag => "#{spec.version}" }
+
+  spec.swift_version = '5.0'
+
+  spec.osx.deployment_target = '10.9'
+  spec.ios.deployment_target = '8.0'
+
+  spec.source_files  = 'Sources/**/*.swift'
+  spec.dependency      'Yams', '>= 2.0.0'
+  spec.frameworks    = 'XCTest'
+end

--- a/GottaGoFast.podspec
+++ b/GottaGoFast.podspec
@@ -15,8 +15,9 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = '5.0'
 
-  spec.osx.deployment_target = '10.9'
-  spec.ios.deployment_target = '8.0'
+  spec.osx.deployment_target     = '10.10'
+  spec.ios.deployment_target     = '8.0'
+  spec.tvos.deployment_target    = '9.0'
 
   spec.source_files  = 'Sources/**/*.swift'
   spec.dependency      'Yams', '>= 2.0.0'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Sergej Jaskiewicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds support for Cocoapods and LICENSE file. 

Necessary to allow exposing tests via TestSpec in OpenCombine.

When merged, please add bump the version to 0.2.1 and add a tag to that commit.